### PR TITLE
Enable custom durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# Workshop-timer
+# Workshop Timer
+
+This simple web app helps facilitate workshop sessions by providing preset timers for each exercise. Select an activity, optionally enter a custom duration, and start the countdown.
+
+## Custom Duration
+
+You can override the default timer length with your own value:
+
+1. Enter the desired number of **minutes** in the input field next to the Start button.
+2. Select an exercise or press **Start**.
+
+If the input is empty or invalid, the app falls back to the preset time for the chosen exercise.

--- a/index.html
+++ b/index.html
@@ -22,11 +22,12 @@
       <div id="progress-bar"></div>
     </div>
 
-    <div class="controls">
-      <button id="start-btn" disabled>Start</button>
-      <button id="stop-btn" disabled>Stop</button>
-      <button id="reset-btn" disabled>Reset</button>
-    </div>
+      <div class="controls">
+        <input type="number" id="duration-input" placeholder="Minutes" min="1">
+        <button id="start-btn" disabled>Start</button>
+        <button id="stop-btn" disabled>Stop</button>
+        <button id="reset-btn" disabled>Reset</button>
+      </div>
   </div>
 
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -12,6 +12,7 @@ const exercises = {
     const startBtn = document.getElementById('start-btn');
     const stopBtn = document.getElementById('stop-btn');
     const resetBtn = document.getElementById('reset-btn');
+    const durationInput = document.getElementById('duration-input');
     const exerciseSelector = document.getElementById('exercise-selector');
     const progressBar = document.getElementById('progress-bar');
 
@@ -47,6 +48,14 @@ const exercises = {
       return `${minutes.toString().padStart(2, '0')}:${remaining.toString().padStart(2, '0')}`;
     }
 
+    function getCustomDuration() {
+      const value = parseFloat(durationInput.value);
+      if (!isNaN(value) && value > 0) {
+        return Math.round(value * 60); // assume minutes
+      }
+      return null;
+    }
+
     function updateDisplay() {
       timerDisplay.textContent = formatTime(totalSeconds);
       if (currentExerciseDuration > 0) {
@@ -57,8 +66,14 @@ const exercises = {
 
     function selectExercise(name, duration, button) {
       stopTimer();
-      currentExerciseDuration = duration;
-      totalSeconds = duration;
+      const custom = getCustomDuration();
+      if (custom !== null) {
+        currentExerciseDuration = custom;
+        totalSeconds = custom;
+      } else {
+        currentExerciseDuration = duration;
+        totalSeconds = duration;
+      }
       exerciseTitle.textContent = name;
       updateDisplay();
       if (selectedExerciseButton) selectedExerciseButton.classList.remove('active');
@@ -71,6 +86,14 @@ const exercises = {
 
     function startTimer() {
       if (isRunning || totalSeconds <= 0) return;
+
+      const custom = getCustomDuration();
+      if (custom !== null) {
+        currentExerciseDuration = custom;
+        totalSeconds = custom;
+        updateDisplay();
+      }
+
       isRunning = true;
       startBtn.disabled = true;
       stopBtn.disabled = false;

--- a/style.css
+++ b/style.css
@@ -113,6 +113,18 @@ body {
       flex: 1 1 100px;
       min-width: 100px;
     }
+
+    .controls input[type="number"] {
+      background-color: #2c2c2c;
+      color: #e0e0e0;
+      border: 1px solid #555;
+      padding: 12px 20px;
+      margin: 5px;
+      font-size: 1em;
+      border-radius: 8px;
+      flex: 1 1 100px;
+      min-width: 100px;
+    }
     .controls button:hover, .exercise-selection button:hover {
       background-color: #6495ED;
       color: #fff;


### PR DESCRIPTION
## Summary
- allow users to enter a custom duration
- honor custom values when selecting exercises or starting the timer
- style the new duration input
- document custom timer usage

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_683fed3af5f8833294e7a90420c88023